### PR TITLE
Pin `jsonfeed` 1.0.0, update usage

### DIFF
--- a/make_index.py
+++ b/make_index.py
@@ -86,4 +86,4 @@ for metadata in metadatas:
     feed.items.append(item)
 
 with open("./feed.json", "w") as f:
-    f.write(feed.toJSON(indent="\t"))
+    f.write(feed.to_json(indent="\t"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 python-frontmatter>=0.5.0
 python-dateutil>=2.8.1
 pytz==2019.1
-git+git://github.com/lukasschwab/jsonfeed.git#egg=jsonfeed
+git+git://github.com/lukasschwab/jsonfeed.git@1.0.0#egg=jsonfeed


### PR DESCRIPTION
## Changes

Does what it says on the tin. `s/toJSON/to_json` to match 1.0.0 usage.

## Testing

Regenerated index.html (ran `make`); no changes.