### PR TITLE
Add BLOG_DOMAIN config for JSON Feed home_page_url and feed_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ Deeply unattractive out of the box? Yes. Easy to customize? I hope so.
 2. `main.go` reads the YAML frontmatter of every Markdown post in `posts` and transforms this into an intermediate Markdown document of headers and metadata, which it pipes to `pandoc`.
 
 
+## Configuration
+
+Behavior can be customized via environment variables prefixed with `BLOG_`:
+
+| Variable | Default | Description |
+|---|---|---|
+| `BLOG_POSTS_DIR` | `posts` | Directory containing Markdown source posts. |
+| `BLOG_GEN_DIR` | `gen` | Directory for generated per-post HTML files. |
+| `BLOG_INDEX_HTML` | `index.html` | Path for the generated index page. |
+| `BLOG_INDEX_TEMPLATE` | `templates/index.html` | Pandoc template for the index page. |
+| `BLOG_FEED_FILE` | `feed.json` | Path for the generated JSON Feed file. |
+| `BLOG_FEED_TITLE` | `blog` | Title of the JSON Feed. |
+| `BLOG_DOMAIN` | *(empty)* | Base URL of the blog (e.g. `https://example.com`). When set, `home_page_url` and `feed_url` are included in the JSON feed, and item URLs are absolute. When empty, item URLs are relative. |
+
 ## Customization
 
 A general rule of thumb: changes to the HTML are predictable; changes to pre-`pandoc` Markdown are unpredictable. Markdown intermediates (like `main.go` uses for the index) are antipatterns, but they do allow pandoc markdown in post titles and abstracts.

--- a/main.go
+++ b/main.go
@@ -36,6 +36,10 @@ type config struct {
 	FeedFile string `envconfig:"FEED_FILE" default:"feed.json"`
 	// FeedTitle is the title of the JSON Feed.
 	FeedTitle string `envconfig:"FEED_TITLE" default:"blog"`
+	// Domain is the base URL of the blog, used for feed metadata.
+	// When set, home_page_url and feed_url are included in the JSON feed,
+	// and item URLs are absolute. When empty, item URLs are relative.
+	Domain string `envconfig:"DOMAIN" default:""`
 }
 
 // postFrontmatter represents the YAML front matter in a Markdown post.
@@ -163,6 +167,9 @@ func generateFeed(cfg config, posts []postMeta) error {
 	var items []jsonfeed.Item
 	for _, p := range posts {
 		url := p.staticPath(cfg.GenDir)
+		if cfg.Domain != "" {
+			url = strings.TrimRight(cfg.Domain, "/") + strings.TrimPrefix(url, ".")
+		}
 
 		item := jsonfeed.NewItem(url)
 		item.URL = url
@@ -188,6 +195,10 @@ func generateFeed(cfg config, posts []postMeta) error {
 	}
 
 	feed := jsonfeed.NewFeed(cfg.FeedTitle, items)
+	if cfg.Domain != "" {
+		feed.HomePageURL = cfg.Domain
+		feed.FeedURL = strings.TrimRight(cfg.Domain, "/") + "/" + cfg.FeedFile
+	}
 	feed.Expired = false
 
 	// Use a JSON encoder instead of feed.ToJSON() to get


### PR DESCRIPTION
The [JSON Feed spec](https://www.jsonfeed.org/version/1.1/) describes `home_page_url` and `feed_url` as "optional but strongly recommended" and says they "should be considered as required for feeds on the public web."

Since the domain is deployment-specific (pandoc-blog is a template/framework), this adds a `BLOG_DOMAIN` env var via the existing `envconfig` setup. When set:

- `home_page_url` and `feed_url` are included in the generated JSON feed.
- Item IDs and URLs become absolute (e.g. `https://example.com/gen/post.html`).

**This is fully backward-compatible:** when `BLOG_DOMAIN` is empty (the default), behavior is unchanged — item URLs remain relative, and `home_page_url`/`feed_url` are omitted from the feed.

Also adds a Configuration section to the README documenting all `BLOG_*` env vars.