### PR TITLE
Update go-jsonfeed; adopt pointer types and ToJSON improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,10 @@ go 1.26.1
 require (
 	github.com/adrg/frontmatter v0.2.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/lukasschwab/go-jsonfeed v0.0.0-20230404010820-b3721e75769e
+	github.com/lukasschwab/go-jsonfeed v0.0.0-20260405014117-912dfa255e52
 )
 
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
-	github.com/lukasschwab/optional v0.0.0-20191006022851-a495ac0ceee7 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,8 @@ github.com/adrg/frontmatter v0.2.0 h1:/DgnNe82o03riBd1S+ZDjd43wAmC6W35q67NHeLkPd
 github.com/adrg/frontmatter v0.2.0/go.mod h1:93rQCj3z3ZlwyxxpQioRKC1wDLto4aXHrbqIsnH9wmE=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
-github.com/lukasschwab/go-jsonfeed v0.0.0-20230404010820-b3721e75769e h1:lvyk0KS5/nnI62ua+XbEdJofpAYlflVkyxaRr1HBjQY=
-github.com/lukasschwab/go-jsonfeed v0.0.0-20230404010820-b3721e75769e/go.mod h1:KObitYDkkHbmVCNA3Z09QweE0RaIFD4zVvtsuB6LCZ8=
-github.com/lukasschwab/optional v0.0.0-20191006022851-a495ac0ceee7 h1:eNLrJ+nXaJ5ZtQD2vvC7FsaZctbobWll0FSiK4fkIjc=
-github.com/lukasschwab/optional v0.0.0-20191006022851-a495ac0ceee7/go.mod h1:fu5mT6INiB5fjYF74VioT5uKpJvxhfplzPnIDQS9RKM=
+github.com/lukasschwab/go-jsonfeed v0.0.0-20260405014117-912dfa255e52 h1:hFi6U4H6G6OngyZTLyvi4ec5RAagERWfBaNaqAGVMdk=
+github.com/lukasschwab/go-jsonfeed v0.0.0-20260405014117-912dfa255e52/go.mod h1:9yWrmW0lh9AyVvf+taKo4AOYPKLXQf1mh1q5qAIJhXc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -19,6 +18,8 @@ import (
 	"github.com/kelseyhightower/envconfig"
 	jsonfeed "github.com/lukasschwab/go-jsonfeed"
 )
+
+func ptr[T any](v T) *T { return &v }
 
 // config holds all configurable paths and values. Defaults can be
 // overridden via environment variables prefixed with BLOG_, e.g.
@@ -172,14 +173,14 @@ func generateFeed(cfg config, posts []postMeta) error {
 		}
 
 		item := jsonfeed.NewItem(url)
-		item.URL = url
-		item.Title = p.Title
+		item.URL = ptr(url)
+		item.Title = ptr(p.Title)
 
 		if !p.Date.IsZero() {
-			item.DatePublished = p.Date.Format(time.RFC3339)
+			item.DatePublished = ptr(p.Date.Format(time.RFC3339))
 		}
 		if p.Abstract != "" {
-			item.Summary = p.Abstract
+			item.Summary = ptr(p.Abstract)
 		}
 
 		// Read the generated HTML to embed in the feed.
@@ -188,7 +189,7 @@ func generateFeed(cfg config, posts []postMeta) error {
 		// abstracts.
 		htmlPath := filepath.Join(cfg.GenDir, strings.TrimSuffix(p.Filename, ".md")+".html")
 		if data, err := os.ReadFile(htmlPath); err == nil {
-			item.ContentHTML = string(data)
+			item.ContentHTML = ptr(string(data))
 		}
 
 		items = append(items, item)
@@ -196,22 +197,16 @@ func generateFeed(cfg config, posts []postMeta) error {
 
 	feed := jsonfeed.NewFeed(cfg.FeedTitle, items)
 	if cfg.Domain != "" {
-		feed.HomePageURL = cfg.Domain
-		feed.FeedURL = strings.TrimRight(cfg.Domain, "/") + "/" + cfg.FeedFile
+		feed.HomePageURL = ptr(cfg.Domain)
+		feed.FeedURL = ptr(strings.TrimRight(cfg.Domain, "/") + "/" + cfg.FeedFile)
 	}
-	feed.Expired = false
+	feed.Expired = ptr(false)
 
-	// Use a JSON encoder instead of feed.ToJSON() to get
-	// tab-indented output with unescaped HTML, matching the
-	// original feed format.
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetIndent("", "\t")
-	enc.SetEscapeHTML(false)
-	if err := enc.Encode(feed); err != nil {
+	data, err := feed.ToJSON()
+	if err != nil {
 		return err
 	}
-	return os.WriteFile(cfg.FeedFile, buf.Bytes(), 0644)
+	return os.WriteFile(cfg.FeedFile, data, 0644)
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -19,8 +19,6 @@ import (
 	jsonfeed "github.com/lukasschwab/go-jsonfeed"
 )
 
-func ptr[T any](v T) *T { return &v }
-
 // config holds all configurable paths and values. Defaults can be
 // overridden via environment variables prefixed with BLOG_, e.g.
 // BLOG_POSTS_DIR, BLOG_FEED_TITLE.
@@ -173,14 +171,14 @@ func generateFeed(cfg config, posts []postMeta) error {
 		}
 
 		item := jsonfeed.NewItem(url)
-		item.URL = ptr(url)
-		item.Title = ptr(p.Title)
+		item.URL = new(url)
+		item.Title = new(p.Title)
 
 		if !p.Date.IsZero() {
-			item.DatePublished = ptr(p.Date.Format(time.RFC3339))
+			item.DatePublished = new(p.Date.Format(time.RFC3339))
 		}
 		if p.Abstract != "" {
-			item.Summary = ptr(p.Abstract)
+			item.Summary = new(p.Abstract)
 		}
 
 		// Read the generated HTML to embed in the feed.
@@ -189,7 +187,7 @@ func generateFeed(cfg config, posts []postMeta) error {
 		// abstracts.
 		htmlPath := filepath.Join(cfg.GenDir, strings.TrimSuffix(p.Filename, ".md")+".html")
 		if data, err := os.ReadFile(htmlPath); err == nil {
-			item.ContentHTML = ptr(string(data))
+			item.ContentHTML = new(string(data))
 		}
 
 		items = append(items, item)
@@ -197,10 +195,10 @@ func generateFeed(cfg config, posts []postMeta) error {
 
 	feed := jsonfeed.NewFeed(cfg.FeedTitle, items)
 	if cfg.Domain != "" {
-		feed.HomePageURL = ptr(cfg.Domain)
-		feed.FeedURL = ptr(strings.TrimRight(cfg.Domain, "/") + "/" + cfg.FeedFile)
+		feed.HomePageURL = new(cfg.Domain)
+		feed.FeedURL = new(strings.TrimRight(cfg.Domain, "/") + "/" + cfg.FeedFile)
 	}
-	feed.Expired = ptr(false)
+	feed.Expired = new(false)
 
 	data, err := feed.ToJSON()
 	if err != nil {


### PR DESCRIPTION
Update go-jsonfeed to 912dfa2. Changes:

- All optional jsonfeed fields now use pointer types (`*string`, `*bool`) instead of `interface{}`-based `opt.String`/`opt.Bool`. Added a generic `ptr` helper for clean conversions.
- Replaced the manual `json.Encoder` workaround with `feed.ToJSON()`, which now produces tab-indented output with unescaped HTML natively.
- Removed unused `encoding/json` import.